### PR TITLE
Test fix

### DIFF
--- a/app/controllers/api/v1/users/recipes_controller.rb
+++ b/app/controllers/api/v1/users/recipes_controller.rb
@@ -27,23 +27,28 @@ class Api::V1::Users::RecipesController < Api::V1::ApplicationController
   end
 
   def create
-    recipe = Recipe.create(
-      user_id: current_user.id,
-      name: params[:recipe][:name]
-    )
-    recipe_ingredients = recipe_ingredient_list(recipe)
-    recipe.update(family: recipe.assign_family)
-    recipe_activity
-    render(
-      json: {
-        status: 201,
-        recipe: {
-          name: recipe.name,
-          ingredients: recipe_ingredients,
-          total_percentage: recipe.total_percent
+    recipe = Recipe.find_by(name: params[:recipe][:name])
+    if !recipe
+      recipe = Recipe.create(
+        user_id: current_user.id,
+        name: params[:recipe][:name]
+      )
+      recipe_ingredients = recipe_ingredient_list(recipe)
+      recipe.update(family: recipe.assign_family)
+      recipe_activity
+      render(
+        json: {
+          status: 201,
+          recipe: {
+            name: recipe.name,
+            ingredients: recipe_ingredients,
+            total_percentage: recipe.total_percent
+          }
         }
-      }
-    )
+       )
+    else
+      render(json: { status: 404, message: 'You already have a recipe with that name' })
+    end
   end
 
   def destroy

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -8,7 +8,7 @@ class Recipe < ApplicationRecord
   has_many :ingredients, through: :recipe_ingredients
   has_many :tags, through: :recipe_tags
   has_many :recipe_tags, dependent: :destroy
-  validates :name, uniqueness: true
+  validates :name, uniqueness: true, presence: true
 
   before_destroy :destroy_all_recipe_ingredients
 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Recipe, 'validations' do
   it { should validate_uniqueness_of :name }
+  it { should validate_presence_of :name }
 end
 
 RSpec.describe Recipe, 'associations' do

--- a/spec/requests/api/v1/users/users_recipes_request_spec.rb
+++ b/spec/requests/api/v1/users/users_recipes_request_spec.rb
@@ -78,6 +78,31 @@ RSpec.describe 'User API' do
       end
     end
 
+    it 'cannot create a recipe with same name as one that already exists' do
+      VCR.use_cassette('dupe_recipes') do
+        user.recipes << create(:recipe, name: 'baguette')
+        list = {
+          name: 'baguette',
+          ingredients: {
+            flour: { amount: 1.00 },
+            water: { amount: 0.62 },
+            yeast: { amount: 0.02 },
+            salt: { amount: 0.02 }
+          }
+        }
+
+        post "/api/v1/users/#{user.email}/recipes",
+          params: { token: token, recipe: list }
+
+        expect(response).to be_success
+
+        result = JSON.parse(response.body, symbolize_names: true)
+
+        expect(result[:status]).to eq(404)
+        expect(result[:message]).to eq('You already have a recipe with that name')
+      end
+    end
+
     it 'user can delete recipe' do
       recipe = user.recipes[0]
       flour  = create(:ingredient, name: 'Flour')


### PR DESCRIPTION
* Adds test for recipe name presence validation
* Adds test to show the user cannot create a recipe that has the same name as one they already have.
  * Shows return of 404 status and custom message
* Changes create in users recipe controller to have conditional if recipe is already in users list of recipes. If it's not there, it will create the recipe and associated records. If it is there, it returns 404 and a message.