### PR TITLE
Refactor routes

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::ApplicationController < ActionController::Base
     token = params[:token]
     if token.present?
       payload = TokiToki.decode(token)
-      @current_user ||= User.find_by_email(payload[0]['sub']['email'])
+      @current_user ||= User.find(payload[0]['sub']['id'])
     end
   end
 

--- a/app/controllers/api/v1/users/follows_controller.rb
+++ b/app/controllers/api/v1/users/follows_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Users::FollowsController < Api::V1::ApplicationController
   before_action :authenticate_user!
 
   def create
-    target = User.find_by(email: params[:target_email])
+    target = User.find(params[:target_id])
     follow = Follow.new(target_id: target.id, user_id: current_user.id)
     follow.user = current_user
     StreamRails.feed_manager.follow_user(follow.user_id, follow.target_id) if follow.save
@@ -13,7 +13,7 @@ class Api::V1::Users::FollowsController < Api::V1::ApplicationController
   end
 
   def destroy
-    target = User.find_by(email: params[:target_email])
+    target = User.find(params[:target_id])
     follow = Follow.find_by(target_id: target.id)
     if follow.user_id == current_user.id
       follow.destroy!

--- a/app/controllers/api/v1/users/recipes_controller.rb
+++ b/app/controllers/api/v1/users/recipes_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::Users::RecipesController < Api::V1::ApplicationController
   end
 
   def show
-    recipe = current_user.recipes.find_by(name: params[:recipe_name])
+    recipe = current_user.recipes.find(params[:recipe_id])
     render(
       status: 200,
       json: Api::V1::RecipeSerializer.new(recipe).attributes

--- a/app/controllers/api/v1/users/recipes_controller.rb
+++ b/app/controllers/api/v1/users/recipes_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::Users::RecipesController < Api::V1::ApplicationController
   end
 
   def destroy
-    recipe = current_user.recipes.find_by_name(params[:recipe_name])
+    recipe = current_user.recipes.find(params[:recipe_id])
     recipe.user.recipes.delete(recipe)
     recipe.destroy
     render(json: { status: 204, message: "Successfully deleted #{recipe.name}" })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,10 +25,10 @@ Rails.application.routes.draw do
         get 'all', to: 'users#index'
 
         # Specific users recipe paths
-        get ':email/recipes', to: 'recipes#index', constraints: { email: /.+@.+\..*/ }
-        get ':email/recipes/:recipe_name', to: 'recipes#show', constraints: { email: /.+@.+\..*/ }
-        post ':email/recipes', to: 'recipes#create', constraints: { email: /.+@.+\..*/ }
-        delete ':email/recipes/:recipe_name', to: 'recipes#destroy', constraints: { email: /.+@.+\..*/ }
+        get ':id/recipes', to: 'recipes#index'#, constraints: { email: /.+@.+\..*/ }
+        get ':id/recipes/:recipe_id', to: 'recipes#show'#, constraints: { email: /.+@.+\..*/ }
+        post ':id/recipes', to: 'recipes#create'#, constraints: { email: /.+@.+\..*/ }
+        delete ':id/recipes/:recipe_id', to: 'recipes#destroy'#, constraints: { email: /.+@.+\..*/ }
       end
 
       # log in with amazon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
         end
 
         # Follow routes
-        post ':email/follow/:target_email', to: 'follows#create', constraints: { email: /.+@.+\..*/, target_email: /.+@.+\..*/ }
-        delete ':email/unfollow/:target_email', to: 'follows#destroy', constraints: { email: /.+@.+\..*/, target_email: /.+@.+\..*/ }
+        post ':id/follow/:target_id', to: 'follows#create'#, constraints: { email: /.+@.+\..*/, target_id: /.+@.+\..*/ }
+        delete ':email/unfollow/:target_email', to: 'follows#destroy'#, constraints: { email: /.+@.+\..*/, target_email: /.+@.+\..*/ }
 
         # all users path
         get 'all', to: 'users#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,11 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :users do
         # Like routes
-        post ':email/like/:recipe_id', to: 'likes#create', constraints: { email: /.+@.+\..*/ }
-
-        delete ':email/unlike/:recipe_id', to: 'likes#destroy', constraints: { email: /.+@.+\..*/ }
+        post ':id/like/:recipe_id', to: 'likes#create'
+        delete ':id/unlike/:recipe_id', to: 'likes#destroy'
 
         # Feed routes
-        scope path: ':email/feeds', constraints: { email: /.+@.+\..*/ }, controller: :feeds, as: 'feed' do
+        scope path: ':id/feeds', controller: :feeds, as: 'feed' do
           get 'me', to: 'feeds#user'
           get 'flat', to: :flat
           get 'aggregated', to: :aggregated
@@ -18,17 +17,17 @@ Rails.application.routes.draw do
         end
 
         # Follow routes
-        post ':id/follow/:target_id', to: 'follows#create'#, constraints: { email: /.+@.+\..*/, target_id: /.+@.+\..*/ }
-        delete ':email/unfollow/:target_email', to: 'follows#destroy'#, constraints: { email: /.+@.+\..*/, target_email: /.+@.+\..*/ }
+        post ':id/follow/:target_id', to: 'follows#create'
+        delete ':id/unfollow/:target_id', to: 'follows#destroy'
 
         # all users path
         get 'all', to: 'users#index'
 
         # Specific users recipe paths
-        get ':id/recipes', to: 'recipes#index'#, constraints: { email: /.+@.+\..*/ }
-        get ':id/recipes/:recipe_id', to: 'recipes#show'#, constraints: { email: /.+@.+\..*/ }
-        post ':id/recipes', to: 'recipes#create'#, constraints: { email: /.+@.+\..*/ }
-        delete ':id/recipes/:recipe_id', to: 'recipes#destroy'#, constraints: { email: /.+@.+\..*/ }
+        get ':id/recipes', to: 'recipes#index'
+        get ':id/recipes/:recipe_id', to: 'recipes#show'
+        post ':id/recipes', to: 'recipes#create'
+        delete ':id/recipes/:recipe_id', to: 'recipes#destroy'
       end
 
       # log in with amazon

--- a/spec/requests/api/v1/new_totals_request_spec.rb
+++ b/spec/requests/api/v1/new_totals_request_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'New recipe totals' do
         }
       }
 
-      post "/api/v1/users/#{user.email}/recipes", params: {
+      post "/api/v1/users/#{user.id}/recipes", params: {
         token: token,
         recipe: list
       }

--- a/spec/requests/api/v1/new_totals_request_spec.rb
+++ b/spec/requests/api/v1/new_totals_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'New recipe totals' do
         }
       }
 
-      post "/api/v1/users/#{user.email}/recipes", params: {
+      post "/api/v1/users/#{user.id}/recipes", params: {
         token: token,
         recipe: list
       }

--- a/spec/requests/api/v1/users/feeds_request_spec.rb
+++ b/spec/requests/api/v1/users/feeds_request_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe 'Feeds' do
 
   it 'feeds#notification' do
     VCR.use_cassette('notification_feeds') do
-      post "/api/v1/users/#{user.email}/follow/#{user2.email}", params: { token: token }
+      post "/api/v1/users/#{user.id}/follow/#{user2.id}", params: { token: token }
 
-      get "/api/v1/users/#{user2.email}/feeds/notification", params: { token: token2 }
+      get "/api/v1/users/#{user2.id}/feeds/notification", params: { token: token2 }
 
       expect(response).to be_successful
 

--- a/spec/requests/api/v1/users/feeds_request_spec.rb
+++ b/spec/requests/api/v1/users/feeds_request_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe 'Feeds' do
           salt: { amount: 0.02 }
         }
       }
-      post "/api/v1/users/#{user.email}/follow/#{user2.email}", params: { token: token }
-      post "/api/v1/users/#{user2.email}/recipes", params: { token: token2, recipe: list }
+      post "/api/v1/users/#{user.id}/follow/#{user2.id}", params: { token: token }
+      post "/api/v1/users/#{user2.id}/recipes", params: { token: token2, recipe: list }
 
-      get "/api/v1/users/#{user.email}/feeds/flat", params: { token: token }
+      get "/api/v1/users/#{user.id}/feeds/flat", params: { token: token }
 
       expect(response).to be_successful
 

--- a/spec/requests/api/v1/users/follow_request_spec.rb
+++ b/spec/requests/api/v1/users/follow_request_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Follow Requests' do
       expect(user1.follows.count).to eq(2)
       expect(user1.follows.first.target_id).to eq(user2.id)
 
-      delete "/api/v1/users/#{user1.email}/unfollow/#{user2.email}",
+      delete "/api/v1/users/#{user1.id}/unfollow/#{user2.id}",
         params: { token: token1 }
 
       user1.reload

--- a/spec/requests/api/v1/users/follow_request_spec.rb
+++ b/spec/requests/api/v1/users/follow_request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Follow Requests' do
 
   it 'can follow a user' do
     VCR.use_cassette('follow') do
-      post "/api/v1/users/#{user1.email}/follow/#{user2.email}",
+      post "/api/v1/users/#{user1.id}/follow/#{user2.id}",
         params: { token: token1 }
 
       expect(response).to be_successful
@@ -22,9 +22,9 @@ RSpec.describe 'Follow Requests' do
 
   it 'can follow more than one user' do
     VCR.use_cassette('follow_more') do
-      post "/api/v1/users/#{user1.email}/follow/#{user2.email}",
+      post "/api/v1/users/#{user1.id}/follow/#{user2.id}",
       params: { token: token1 }
-      post "/api/v1/users/#{user1.email}/follow/#{user3.email}",
+      post "/api/v1/users/#{user1.id}/follow/#{user3.id}",
         params: { token: token1 }
 
       expect(response).to be_successful

--- a/spec/requests/api/v1/users/user_likes_request_spec.rb
+++ b/spec/requests/api/v1/users/user_likes_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'User Likes' do
       recipe = user_2.recipes[1]
       expect(user_1.likes.count).to eq(0)
 
-      post "/api/v1/users/#{user_1.email}/like/#{recipe.id}", params: { token: token_1 }
+      post "/api/v1/users/#{user_1.id}/like/#{recipe.id}", params: { token: token_1 }
 
       expect(response).to be_successful
 
@@ -25,7 +25,7 @@ RSpec.describe 'User Likes' do
       expect(like[:target_id]).to eq(user_2.id)
       expect(like[:recipe_id]).to eq(recipe.id)
 
-      get "/api/v1/users/#{user_2.email}/feeds/notification", params: { token: token_2 }
+      get "/api/v1/users/#{user_2.id}/feeds/notification", params: { token: token_2 }
 
       notify = JSON.parse(response.body, symbolize_names: true)
 
@@ -40,11 +40,11 @@ RSpec.describe 'User Likes' do
       recipe = user_2.recipes[0]
       expect(user_2.likes.count).to eq(0)
 
-      post "/api/v1/users/#{user_1.email}/like/#{recipe.id}", params: { token: token_1 }
+      post "/api/v1/users/#{user_1.id}/like/#{recipe.id}", params: { token: token_1 }
 
       expect(user_1.likes.count).to eq(1)
 
-      delete "/api/v1/users/#{user_1.email}/unlike/#{recipe.id}", params: { token: token_1 }
+      delete "/api/v1/users/#{user_1.id}/unlike/#{recipe.id}", params: { token: token_1 }
 
       expect(response).to be_successful
 

--- a/spec/requests/api/v1/users/users_recipes_request_spec.rb
+++ b/spec/requests/api/v1/users/users_recipes_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'User API' do
 
   context 'user recipes' do
     it 'returns list of recipes for a user with params' do
-      get "/api/v1/users/#{user.email}/recipes", params: { token: token }
+      get "/api/v1/users/#{user.id}/recipes", params: { token: token }
 
       expect(response).to be_successful
 
@@ -31,7 +31,7 @@ RSpec.describe 'User API' do
     end
 
     it 'does not return anything without token in params' do
-      get "/api/v1/users/#{user.email}/recipes"
+      get "/api/v1/users/#{user.id}/recipes"
 
       expect(response).to_not be_successful
       expect(response).to have_http_status(401)
@@ -50,7 +50,7 @@ RSpec.describe 'User API' do
         create(:recipe_ingredient, recipe: recipe)
       end
 
-      get "/api/v1/users/#{user.email}/recipes/#{recipe.name}",
+      get "/api/v1/users/#{user.id}/recipes/#{recipe.id}",
         params: { token: token }
 
       expect(response).to be_successful
@@ -75,7 +75,7 @@ RSpec.describe 'User API' do
           }
         }
 
-        post "/api/v1/users/#{user.email}/recipes",
+        post "/api/v1/users/#{user.id}/recipes",
           params: { token: token, recipe: list }
 
         expect(response).to be_successful
@@ -105,7 +105,7 @@ RSpec.describe 'User API' do
           }
         }
 
-        post "/api/v1/users/#{user.email}/recipes",
+        post "/api/v1/users/#{user.id}/recipes",
           params: { token: token, recipe: list }
 
         expect(response).not_to be_successful
@@ -130,7 +130,7 @@ RSpec.describe 'User API' do
         }
         tags = %w[Lean Baguette French\ Bread]
 
-        post "/api/v1/users/#{user.email}/recipes",
+        post "/api/v1/users/#{user.id}/recipes",
           params: { token: token, recipe: list, tags: tags }
 
         expect(response).to be_successful
@@ -149,7 +149,7 @@ RSpec.describe 'User API' do
         flour  = create(:ingredient, name: 'Flour')
         recipe.recipe_ingredients << create(:recipe_ingredient, ingredient_id: flour.id)
 
-        delete "/api/v1/users/#{user.email}/recipes/#{recipe.name}",
+        delete "/api/v1/users/#{user.id}/recipes/#{recipe.id}",
           params: { token: token }
 
         expect(response).to be_successful
@@ -173,10 +173,12 @@ RSpec.describe 'User API' do
             salt: { amount: 0.02 }
           }
         }
-        post "/api/v1/users/#{user.email}/recipes",
+        post "/api/v1/users/#{user.id}/recipes",
           params: { recipe: list, token: token }
 
-        get "/api/v1/users/#{user.email}/recipes/#{list[:name]}",
+        new_recipe = JSON.parse(response.body, symbolize_names: true)
+
+        get "/api/v1/users/#{user.id}/recipes/#{new_recipe[:id]}",
           params: { token: token }
 
         expect(response).to be_successful


### PR DESCRIPTION
Refactors routes to use ids instead of emails.
- Refactors specs to adhere to new routes
- Refactor `#current_user` to use id